### PR TITLE
update docker-compose to reflect upstream repo

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -38,29 +38,3 @@ jobs:
         run: |
           cp .github/docker-compose.dry-run.yml docker-compose.override.yml
           docker compose up --attach ac-db-import --attach ac-worldserver --attach ac-authserver
-
-  test-dev-install-process:
-    env:
-      COMPOSE_DOCKER_CLI_BUILD: 1
-      DOCKER_BUILDKIT: 1
-      BUILDKIT_INLINE_CACHE: 1
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          # - os: macos-latest TODO: install docker
-          # - os: ubuntu-20.04
-          - os: ubuntu-latest
-          # - os: windows-latest TODO: install docker
-    steps:
-      - uses: actions/checkout@v2
-
-      # TODO: fix after this is solved: https://github.com/docker/compose/issues/9515#issuecomment-1303538917
-      - name: Test
-        shell: bash
-        run: |
-          cp .github/docker-compose.dev-server.yml docker-compose.override.yml
-          cp .github/config.sh config.sh
-          docker compose up -d ac-dev-database
-          docker compose run --no-deps ac-dev-server bash -c "./acore.sh compiler build"
-          docker compose run --no-deps ac-dev-server bash -c "./env/dist/bin/dbimport"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - 8085
     volumes:
       - ./scripts/lua:/azerothcore/env/dist/bin/lua_scripts/scripts
-      - ${DOCKER_VOL_CLIENT_DATA:-ac-client-data]:/azerothcore/env/dist/data:ro
+      - "${DOCKER_VOL_CLIENT_DATA:-ac-client-data}:/azerothcore/env/dist/data:ro"
 
     environment:
       AC_DATA_DIR: "/azerothcore/env/dist/data"
@@ -113,7 +113,7 @@ services:
     <<: *networks
     image: acore/ac-wotlk-client-data:${DOCKER_IMAGE_TAG:-7.0.0-dev.1}
     volumes:
-      - ${DOCKER_VOL_CLIENT_DATA:-ac-client-data]:/azerothcore/env/dist/data
+      - "${DOCKER_VOL_CLIENT_DATA:-ac-client-data}:/azerothcore/env/dist/data"
 
   ac-db-import:
     <<: *ac-shared-conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,75 +131,6 @@ services:
         condition: service_healthy
 
 
-  ac-dev-database:
-    image: mysql:8.0
-    restart: unless-stopped
-    profiles: [dev]
-    cap_add:
-      - SYS_NICE # CAP_SYS_NICE
-    ports:
-      - ${DOCKER_DB_EXTERNAL_PORT:-63300}:3306
-      - ${DOCKER_WORLD_EXTERNAL_PORT:-8085}:8085
-      - ${DOCKER_SOAP_EXTERNAL_PORT:-7878}:7878
-      - ${DOCKER_AUTH_EXTERNAL_PORT:-3724}:3724
-    expose:
-      - 3306
-    environment:
-      - MYSQL_ROOT_PASSWORD=${DOCKER_DB_ROOT_PASSWORD:-password}
-    volumes:
-      - type: volume
-        source: ac-dev-database
-        target: /var/lib/mysql
-    healthcheck:
-      test: '/usr/bin/mysql --user=root --password=$$MYSQL_ROOT_PASSWORD --execute "SHOW DATABASES;"'
-      interval: 2s
-      timeout: 40s
-      retries: 20
-    networks:
-      ac-dev-network:
-        aliases:
-          - ac-database # needed by the server *.conf file
-
-  ac-dev-server:
-    tty: true
-    privileged: true
-    user: root
-    image: acore/ac-wotlk-dev-server:${DOCKER_IMAGE_TAG:-7.0.0-dev.1}
-    environment:
-      DATAPATH: "/azerothcore/env/dist/data"
-      DOCKER_ETC_FOLDER: "env/dist/etc"
-      AC_LOGIN_DATABASE_INFO: "ac-database;3306;root;${DOCKER_DB_ROOT_PASSWORD:-password};acore_auth"
-      AC_WORLD_DATABASE_INFO: "ac-database;3306;root;${DOCKER_DB_ROOT_PASSWORD:-password};acore_world"
-      AC_CHARACTER_DATABASE_INFO: "ac-database;3306;root;${DOCKER_DB_ROOT_PASSWORD:-password};acore_characters"
-      AC_DATA_DIR: "/azerothcore/env/dist/data"
-      AC_LOGS_DIR: "/azerothcore/env/dist/logs"
-    profiles: [dev]
-    volumes:
-      - ac-dev-server:/azerothcore
-      - ./var/shared:/azerothcore/var/shared
-    # network_mode: service:ac-dev-database
-    working_dir: /azerothcore
-    depends_on:
-      ac-dev-database:
-        condition: service_healthy
-    networks:
-      - ac-dev-network
-
-  ac-dev-tools:
-    <<: *ac-shared-conf
-    image: acore/ac-wotlk-tools:${DOCKER_IMAGE_TAG:-7.0.0-dev.1}
-    working_dir: /azerothcore/env/client/
-    cap_add:
-      - SYS_NICE # CAP_SYS_NICE
-    volumes:
-      - ${DOCKER_CLIENT_DATA_FOLDER:-./var/client}:/azerothcore/env/client/Data
-      - ${DOCKER_VOL_TOOLS_CAMERAS:-ac-client-data-cameras}:/azerothcore/env/dist/data/Cameras
-      - ${DOCKER_VOL_TOOLS_DBC:-ac-client-data-dbc}:/azerothcore/env/client/dbc
-      - ${DOCKER_VOL_TOOLS_MAPS:-ac-client-data-maps}:/azerothcore/env/client/maps
-      - ${DOCKER_VOL_TOOLS_VMAPS:-ac-client-data-vmaps}:/azerothcore/env/client/vmaps
-      - ${DOCKER_VOL_TOOLS_MMAPS:-ac-client-data-mmaps}:/azerothcore/env/client/mmaps
-    profiles: [dev]
-
   phpmyadmin:
     <<: *networks
     image: phpmyadmin
@@ -207,20 +138,11 @@ services:
       - 8080:80
     environment:
       - PMA_ARBITRARY=1
-    profiles: [dev]
+    profiles: []
 
 volumes:
   ac-database:
   ac-client-data:
-  # Volumes for development elow this line
-  ac-dev-server:
-  ac-dev-database:
-  ac-client-data-cameras:
-  ac-client-data-dbc:
-  ac-client-data-maps:
-  ac-client-data-vmaps:
-  ac-client-data-mmaps:
 
 networks:
   ac-network:
-  ac-dev-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,10 +53,8 @@ services:
       - 8085
     volumes:
       - ./scripts/lua:/azerothcore/env/dist/bin/lua_scripts/scripts
-      - ${DOCKER_VOL_TOOLS_DBC:-ac-client-data-dbc}:/azerothcore/env/dist/data/dbc:ro
-      - ${DOCKER_VOL_TOOLS_MAPS:-ac-client-data-maps}:/azerothcore/env/dist/data/maps:ro
-      - ${DOCKER_VOL_TOOLS_VMAPS:-ac-client-data-vmaps}:/azerothcore/env/dist/data/vmaps:ro
-      - ${DOCKER_VOL_TOOLS_MMAPS:-ac-client-data-mmaps}:/azerothcore/env/dist/data/mmaps:ro
+      - ${DOCKER_VOL_CLIENT_DATA:-ac-client-data]:/azerothcore/env/dist/data:ro
+
     environment:
       AC_DATA_DIR: "/azerothcore/env/dist/data"
       AC_LOGS_DIR: "/azerothcore/env/dist/logs"
@@ -68,7 +66,7 @@ services:
       ac-eluna-ts-dev:
         condition: service_started
       ac-client-data:
-        condition: service_started
+        condition: service_completed_successfully
       ac-db-import:
         condition: service_completed_successfully
 
@@ -115,16 +113,11 @@ services:
     <<: *networks
     image: acore/ac-wotlk-client-data:${DOCKER_IMAGE_TAG:-7.0.0-dev.1}
     volumes:
-      - ${DOCKER_VOL_TOOLS_CAMERAS:-ac-client-data-cameras}:/azerothcore/env/dist/data/Cameras
-      - ${DOCKER_VOL_TOOLS_DBC:-ac-client-data-dbc}:/azerothcore/env/dist/data/dbc
-      - ${DOCKER_VOL_TOOLS_MAPS:-ac-client-data-maps}:/azerothcore/env/dist/data/maps
-      - ${DOCKER_VOL_TOOLS_VMAPS:-ac-client-data-vmaps}:/azerothcore/env/dist/data/vmaps
-      - ${DOCKER_VOL_TOOLS_MMAPS:-ac-client-data-mmaps}:/azerothcore/env/dist/data/mmaps
+      - ${DOCKER_VOL_CLIENT_DATA:-ac-client-data]:/azerothcore/env/dist/data
 
   ac-db-import:
     <<: *ac-shared-conf
-    image: acore/ac-wotlk-worldserver:${DOCKER_IMAGE_TAG:-7.0.0-dev.1}
-    command: ./env/dist/bin/dbimport
+    image: acore/ac-wotlk-db-import:${DOCKER_IMAGE_TAG:-7.0.0-dev.1}
     environment:
       AC_DISABLE_INTERACTIVE: "1"
       AC_DATA_DIR: "/azerothcore/env/dist/data"
@@ -133,7 +126,10 @@ services:
       AC_WORLD_DATABASE_INFO: "ac-database;3306;root;${DOCKER_DB_ROOT_PASSWORD:-password};acore_world"
       AC_CHARACTER_DATABASE_INFO: "ac-database;3306;root;${DOCKER_DB_ROOT_PASSWORD:-password};acore_characters"
       AC_CLOSE_IDLE_CONNECTIONS: "0"
-    #profiles: [db-import]
+    depends_on:
+      ac-database:
+        condition: service_healthy
+
 
   ac-dev-database:
     image: mysql:8.0
@@ -215,6 +211,8 @@ services:
 
 volumes:
   ac-database:
+  ac-client-data:
+  # Volumes for development elow this line
   ac-dev-server:
   ac-dev-database:
   ac-client-data-cameras:


### PR DESCRIPTION
This makes a few changes to `docker-compose.yml` in order to support `azerothcore/azerothcore-wotlk`

this requires 2 pull requests to be merged into the upstream repo:

- https://github.com/azerothcore/azerothcore-wotlk/pull/17530
- https://github.com/azerothcore/azerothcore-wotlk/pull/17529

main changes:
- make worldserver's dependency on client-data be `service_completed_successfully`, since the client data container is now a "job" style container and downloads the client data once
- Use a single volume for client data
    - using 5 volumes isn't necessary
    - the "marker" of which client data version is stored in the datadir, and with 5 separate volumes it wouldn't persist
- let the db-import use its own container
    - the db-import relies on hundreds of megabytes of sql files. 
    - Keeping the sql its own container keeps the worldserver and authserver leaner, and it respects the "single responsibility principle" better
- (proposal) remove the development server from this repo
    - if someone wants to develop on azerothcore with a devcontainer, they should use the one that's in the main repo
    - none of the containers in general ship with source code, and I'm of the opinion that they shouldn't in the first place
    - Naturally, this breaks the dev container in this context, since it requires the source code of azerothcore to function
    - If this repo is in fact scoped for development of azerothcore, I can add it back and ensure basic functionality
    - TODO: update readme to reflect this change

In the mean time of the 3 PRs getting merged, I recommend users look into running their server with the `azerothcore/azerothcore-wotlk` repo. If you can run `docker compose up` with this repo, you can run `docker compose up --build` with that one. the database should seamlessly transfer over. I'd be happy to chat about the process that goes into this (it starts with taking a backup) in the `support-docker` channel in the AzerothCore Discord (@mynameismeat)